### PR TITLE
Return start/end offset of each match

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ sourceCompatibility = 10
 targetCompatibility = 10
 group = "io.thekraken"
 archivesBaseName = "grok"
-version = '0.1.6-SNAPSHOT'
+version = '0.1.7-SNAPSHOT'
 
 dependencies {
   compile "org.apache.commons:commons-lang3:3.7"

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,8 @@ repositories {
   mavenCentral()
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = 10
+targetCompatibility = 10
 group = "io.thekraken"
 archivesBaseName = "grok"
 version = '0.1.6-SNAPSHOT'

--- a/src/main/java/io/thekraken/grok/api/Entity.java
+++ b/src/main/java/io/thekraken/grok/api/Entity.java
@@ -1,11 +1,17 @@
 package io.thekraken.grok.api;
 
+import com.google.common.collect.Lists;
+
+import java.util.List;
+
 public class Entity {
-    public final String value;
+    public Object value;
     public final int start;
     public final int end;
 
-    public Entity(String value, int start, int end) {
+    public final List<Entity> additionalEntities = Lists.newLinkedList();
+
+    public Entity(Object value, int start, int end) {
         this.value = value;
         this.start = start;
         this.end = end;

--- a/src/main/java/io/thekraken/grok/api/Entity.java
+++ b/src/main/java/io/thekraken/grok/api/Entity.java
@@ -1,0 +1,18 @@
+package io.thekraken.grok.api;
+
+public class Entity {
+    public final String value;
+    public final int start;
+    public final int end;
+
+    public Entity(String value, int start, int end) {
+        this.value = value;
+        this.start = start;
+        this.end = end;
+    }
+
+    @Override
+    public String toString() {
+        return value + "[" + start + "," + end + "]";
+    }
+}

--- a/src/main/java/io/thekraken/grok/api/GrokCompiler.java
+++ b/src/main/java/io/thekraken/grok/api/GrokCompiler.java
@@ -150,10 +150,7 @@ public class GrokCompiler {
       // Match %{Foo=regex} -> add new regex definition
       if (m.find()) {
         continueIteration = true;
-        Map<String, String> group =
-            GrokUtils.namedGroups(m, namedGroups).entrySet().stream()
-                .filter(e -> e.getValue().value != null)
-                .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().value));
+        Map<String, String> group = GrokUtils.namedGroups(m, namedGroups);
         if (group.get("definition") != null) {
           patternDefinitions.put(group.get("pattern"), group.get("definition"));
           group.put("name", group.get("name") + "=" + group.get("definition"));

--- a/src/main/java/io/thekraken/grok/api/GrokCompiler.java
+++ b/src/main/java/io/thekraken/grok/api/GrokCompiler.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 
@@ -149,7 +150,10 @@ public class GrokCompiler {
       // Match %{Foo=regex} -> add new regex definition
       if (m.find()) {
         continueIteration = true;
-        Map<String, String> group = GrokUtils.namedGroups(m, namedGroups);
+        Map<String, String> group =
+            GrokUtils.namedGroups(m, namedGroups).entrySet().stream()
+                .filter(e -> e.getValue().value != null)
+                .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().value));
         if (group.get("definition") != null) {
           patternDefinitions.put(group.get("pattern"), group.get("definition"));
           group.put("name", group.get("name") + "=" + group.get("definition"));

--- a/src/main/java/io/thekraken/grok/api/GrokUtils.java
+++ b/src/main/java/io/thekraken/grok/api/GrokUtils.java
@@ -42,11 +42,25 @@ public class GrokUtils {
     return namedGroups;
   }
 
-  public static Map<String, Entity> namedGroups(Matcher matcher, Set<String> groupNames) {
+  public static Map<String, String> namedGroups(Matcher matcher, Set<String> groupNames) {
+    Map<String, String> namedGroups = new LinkedHashMap<>();
+    for (String groupName : groupNames) {
+      String groupValue = matcher.group(groupName);
+      if (groupValue != null) {
+        namedGroups.put(groupName, groupValue);
+      }
+    }
+    return namedGroups;
+  }
+
+  public static Map<String, Entity> namedGroupsWithOffset(Matcher matcher, Set<String> groupNames) {
     Map<String, Entity> namedGroups = new LinkedHashMap<>();
     for (String groupName : groupNames) {
-      Entity entity = new Entity(matcher.group(groupName), matcher.start(groupName), matcher.end(groupName));
-      namedGroups.put(groupName, entity);
+      String groupValue = matcher.group(groupName);
+      if (groupValue != null) {
+        Entity entity = new Entity(groupValue, matcher.start(groupName), matcher.end(groupName));
+        namedGroups.put(groupName, entity);
+      }
     }
     return namedGroups;
   }

--- a/src/main/java/io/thekraken/grok/api/GrokUtils.java
+++ b/src/main/java/io/thekraken/grok/api/GrokUtils.java
@@ -42,11 +42,11 @@ public class GrokUtils {
     return namedGroups;
   }
 
-  public static Map<String, String> namedGroups(Matcher matcher, Set<String> groupNames) {
-    Map<String, String> namedGroups = new LinkedHashMap<String, String>();
+  public static Map<String, Entity> namedGroups(Matcher matcher, Set<String> groupNames) {
+    Map<String, Entity> namedGroups = new LinkedHashMap<>();
     for (String groupName : groupNames) {
-      String groupValue = matcher.group(groupName);
-      namedGroups.put(groupName, groupValue);
+      Entity entity = new Entity(matcher.group(groupName), matcher.start(groupName), matcher.end(groupName));
+      namedGroups.put(groupName, entity);
     }
     return namedGroups;
   }

--- a/src/test/java/io/thekraken/grok/api/ApacheDataTypeTest.java
+++ b/src/test/java/io/thekraken/grok/api/ApacheDataTypeTest.java
@@ -14,8 +14,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Map;
 
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -36,17 +35,16 @@ public class ApacheDataTypeTest {
 
         System.out.println(line);
         Match gm = g.match(line);
-        Map<String, Object> map = gm.capture();
+        Map<String, Entity> map = gm.capture();
 
         assertNotEquals("{\"Error\":\"Error\"}", gm.toJson());
         Instant ts = ZonedDateTime.of(2004, 03, 07, 16, 45, 56, 0, ZoneOffset.ofHours(-8)).toInstant();
-        assertTrue(map.get("timestamp").equals(ts));
-        assertTrue(map.get("response").equals(Integer.valueOf(401)));
-        assertTrue(map.get("ident").equals(Boolean.FALSE));
-        assertTrue(map.get("httpversion").equals(Float.valueOf(1.1f)));
-        assertTrue(map.get("bytes").equals(Long.valueOf(12846)));
-        assertTrue(map.get("verb").equals("GET"));
-
+        assertEquals(ts, map.get("timestamp").value);
+        assertEquals(401, map.get("response").value);
+        assertEquals(Boolean.FALSE, map.get("ident").value);
+        assertEquals(1.1f, map.get("httpversion").value);
+        assertEquals(12846L, map.get("bytes").value);
+        assertEquals("GET[47,50]", map.get("verb").toString());
     }
 
     @Test
@@ -54,18 +52,17 @@ public class ApacheDataTypeTest {
         Grok g = compiler.compile("%{IPORHOST:clientip} %{USER:ident:boolean} %{USER:auth} \\[%{HTTPDATE:timestamp:date:dd/MMM/yyyy:HH:mm:ss Z}\\] \"(?:%{WORD:verb:string} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion:float})?|%{DATA:rawrequest})\" %{NUMBER:response:int} (?:%{NUMBER:bytes:long}|-)");
 
         Match gm = g.match(line);
-        Map<String, Object> map = gm.capture();
+        Map<String, Entity> map = gm.capture();
 
         assertNotEquals("{\"Error\":\"Error\"}", gm.toJson());
 
         Instant ts = ZonedDateTime.of(2004, 03, 07, 16, 45, 56, 0, ZoneOffset.ofHours(-8)).toInstant();
-        assertTrue(map.get("timestamp").equals(ts));
-        assertTrue(map.get("response").equals(Integer.valueOf(401)));
-        assertTrue(map.get("ident").equals(Boolean.FALSE));
-        assertTrue(map.get("httpversion").equals(Float.valueOf(1.1f)));
-        assertTrue(map.get("bytes").equals(Long.valueOf(12846)));
-        assertTrue(map.get("verb").equals("GET"));
-
+        assertEquals(ts, map.get("timestamp").value);
+        assertEquals(401, map.get("response").value);
+        assertEquals(Boolean.FALSE, map.get("ident").value);
+        assertEquals(1.1f, map.get("httpversion").value);
+        assertEquals(12846L, map.get("bytes").value);
+        assertEquals("GET[47,50]", map.get("verb").toString());
     }
 
 }

--- a/src/test/java/io/thekraken/grok/api/CaptureTest.java
+++ b/src/test/java/io/thekraken/grok/api/CaptureTest.java
@@ -38,8 +38,7 @@ public class CaptureTest {
         assertEquals("Hello World", m.getSubject());
         Map<String, Object> map = m.capture();
         assertEquals(1, map.size());
-        assertEquals("Hello World", map.get("foo"));
-        assertEquals("{foo=Hello World}", map.toString());
+        assertEquals("{foo=Hello World[0,11]}", map.toString());
     }
 
     @Test
@@ -52,9 +51,7 @@ public class CaptureTest {
         assertEquals("Hello World", m.getSubject());
         Map<String, Object> map = m.capture();
         assertEquals(2, map.size());
-        assertEquals("Hello", map.get("foo"));
-        assertEquals("World", map.get("bar"));
-        assertEquals("{bar=World, foo=Hello}", map.toString());
+        assertEquals("{bar=World[6,11], foo=Hello[0,5]}", map.toString());
     }
 
     @Test
@@ -67,9 +64,7 @@ public class CaptureTest {
         assertEquals("Hello World", m.getSubject());
         Map<String, Object> map = m.capture();
         assertEquals(2, map.size());
-        assertEquals("Hello World", map.get("foo"));
-        assertEquals("World", map.get("bar"));
-        assertEquals("{bar=World, foo=Hello World}", map.toString());
+        assertEquals("{bar=World[6,11], foo=Hello World[0,11]}", map.toString());
     }
 
     @Test
@@ -94,8 +89,8 @@ public class CaptureTest {
         Match m = grok.match("Hello");
         Map<String, Object> map = m.capture();
         assertEquals(1, map.size());
-        assertEquals("Hello", map.get(subname).toString());
-        assertEquals("{abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_abcdef=Hello}", map.toString());
+        assertEquals("Hello[0,5]", map.get(subname).toString());
+        assertEquals("{abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_abcdef=Hello[0,5]}", map.toString());
     }
 
     @Test
@@ -107,7 +102,7 @@ public class CaptureTest {
         Map<String, Object> map = m.capture();
         assertEquals(map.size(), 1);
         assertNull(map.get("ghijk"));
-        assertEquals(map.get("abcdef"), "abcdef");
+        assertEquals(map.get("abcdef").toString(), "abcdef[0,6]");
     }
     
     @SuppressWarnings("unchecked")
@@ -118,8 +113,8 @@ public class CaptureTest {
         Map<String, Object> map = m.capture();
     	assertEquals(map.size(), 1);
     	assertEquals(((List<Object>) (map.get("id"))).size(),2);
-    	assertEquals(((List<Object>) (map.get("id"))).get(0),"123");
-    	assertEquals(((List<Object>) (map.get("id"))).get(1),"456");
+    	assertEquals(((List<Object>) (map.get("id"))).get(0).toString(),"123[0,3]");
+    	assertEquals(((List<Object>) (map.get("id"))).get(1).toString(),"456[4,7]");
     }
 
     @SuppressWarnings("unchecked")
@@ -129,11 +124,11 @@ public class CaptureTest {
         Match m = grok.match("foo 123 bar");
         Map<String, Object> map = m.captureFlattened();
         assertEquals(map.size(), 1);
-        assertEquals(map.get("id"), "123");
+        assertEquals(map.get("id").toString(), "123[4,7]");
         Match m2 = grok.match("bar 123 foo");
         map = m2.captureFlattened();
         assertEquals(map.size(), 1);
-        assertEquals(map.get("id"), "123");
+        assertEquals(map.get("id").toString(), "123[4,7]");
 
         grok = compiler.compile("%{INT:id} %{INT:id}");
         Match m3 = grok.match("123 456");

--- a/src/test/java/io/thekraken/grok/api/GrokTest.java
+++ b/src/test/java/io/thekraken/grok/api/GrokTest.java
@@ -76,7 +76,7 @@ public class GrokTest {
 
         Grok staticGrok = compiler.compile("%{USERNAME}");
         Match gm = staticGrok.match("root");
-        Map<String, Object> map = gm.capture();
+        Map<String, Entity> map = gm.capture();
         assertEquals("{USERNAME=root[0,4]}", map.toString());
 
         gm = staticGrok.match("r00t");
@@ -102,7 +102,7 @@ public class GrokTest {
         Grok g = compiler.compile("%{USERNAME}");
 
         Match gm = g.match("root");
-        Map<String, Object> map = gm.capture();
+        Map<String, Entity> map = gm.capture();
         assertEquals("{USERNAME=root[0,4]}", map.toString());
 
         gm = g.match("r00t");
@@ -127,7 +127,7 @@ public class GrokTest {
         Grok g = compiler.compile("%{USER}");
 
         Match gm = g.match("root");
-        Map<String, Object> map = gm.capture();
+        Map<String, Entity> map = gm.capture();
         assertEquals("{USER=root[0,4]}", map.toString());
 
         gm = g.match("r00t");
@@ -152,7 +152,7 @@ public class GrokTest {
         Grok g = compiler.compile("%{NUMBER}");
 
         Match gm = g.match("-42");
-        Map<String, Object> map = gm.capture();
+        Map<String, Entity> map = gm.capture();
         assertEquals("{NUMBER=-42[0,3]}", map.toString());
 
     }
@@ -162,7 +162,7 @@ public class GrokTest {
         Grok g = compiler.compile("%{WORD}");
 
         Match gm = g.match("a");
-        Map<String, Object> map = gm.capture();
+        Map<String, Entity> map = gm.capture();
         assertEquals("{WORD=a[0,1]}", map.toString());
 
         gm = g.match("abc");
@@ -176,7 +176,7 @@ public class GrokTest {
         Grok g = compiler.compile("%{SPACE}");
 
         Match gm = g.match("abc dc");
-        Map<String, Object> map = gm.capture();
+        Map<String, Entity> map = gm.capture();
         assertEquals("{SPACE=[0,0]}", map.toString());
 
     }
@@ -186,7 +186,7 @@ public class GrokTest {
         Grok g = compiler.compile("%{NUMBER}");
 
         Match gm = g.match("Something costs $55.4!");
-        Map<String, Object> map = gm.capture();
+        Map<String, Entity> map = gm.capture();
         assertEquals("{NUMBER=55.4[17,21]}", map.toString());
 
     }
@@ -196,7 +196,7 @@ public class GrokTest {
         Grok g = compiler.compile("%{NOTSPACE}");
 
         Match gm = g.match("abc dc");
-        Map<String, Object> map = gm.capture();
+        Map<String, Entity> map = gm.capture();
         assertEquals("{NOTSPACE=abc[0,3]}", map.toString());
 
     }
@@ -206,7 +206,7 @@ public class GrokTest {
         Grok g = compiler.compile("%{QUOTEDSTRING:text}");
 
         Match gm = g.match("\"abc dc\"");
-        Map<String, Object> map = gm.capture();
+        Map<String, Entity> map = gm.capture();
         assertEquals("{text=abc dc[1,7]}", map.toString());
     }
 
@@ -215,7 +215,7 @@ public class GrokTest {
         Grok g = compiler.compile("%{UUID}");
 
         Match gm = g.match("61243740-4786-11e3-86a7-0002a5d5c51b");
-        Map<String, Object> map = gm.capture();
+        Map<String, Entity> map = gm.capture();
         assertEquals("{UUID=61243740-4786-11e3-86a7-0002a5d5c51b[0,36]}", map.toString());
 
         gm = g.match("7F8C7CB0-4786-11E3-8F96-0800200C9A66");
@@ -233,7 +233,7 @@ public class GrokTest {
         Grok g = compiler.compile("%{MAC}");
 
         Match gm = g.match("5E:FF:56:A2:AF:15");
-        Map<String, Object> map = gm.capture();
+        Map<String, Entity> map = gm.capture();
         assertEquals("{MAC=5E:FF:56:A2:AF:15[0,17]}", map.toString());
 
     }
@@ -243,7 +243,7 @@ public class GrokTest {
         Grok g = compiler.compile("%{IPORHOST}");
 
         Match gm = g.match("www.google.fr");
-        Map<String, Object> map = gm.capture();
+        Map<String, Entity> map = gm.capture();
         assertEquals("{IPORHOST=www.google.fr[0,13]}", map.toString());
 
         gm = g.match("www.google.com");
@@ -256,7 +256,7 @@ public class GrokTest {
         Grok g = compiler.compile("%{HOSTPORT}");
 
         Match gm = g.match("www.google.fr:80");
-        Map<String, Object> map = gm.capture();
+        Map<String, Entity> map = gm.capture();
         assertEquals("www.google.fr:80[0,16]", map.get("HOSTPORT").toString());
         assertEquals("www.google.fr[0,13]", map.get("IPORHOST").toString());
         assertEquals("80[14,16]", map.get("PORT").toString());
@@ -268,7 +268,7 @@ public class GrokTest {
 
         Match gm =
                 g.match("112.169.19.192 - - [06/Mar/2013:01:36:30 +0900] \"GET / HTTP/1.1\" 200 44346 \"-\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.152 Safari/537.22\"");
-        Map<String, Object> map = gm.capture();
+        Map<String, Entity> map = gm.capture();
         assertNotNull(gm.toJson());
         assertEquals(
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.152 Safari/537.22[80,200]",
@@ -325,7 +325,7 @@ public class GrokTest {
         int i = 0;
         for (String day : days) {
             Match m = grok.match(day);
-            Map<String, Object> map = m.capture();
+            Map<String, Entity> map = m.capture();
             assertNotNull(map);
             assertEquals(((Entity) map.get("DAY")).value, days.get(i));
             i++;
@@ -341,7 +341,7 @@ public class GrokTest {
         System.out.println("Starting test with ip");
         while ((line = br.readLine()) != null) {
             Match gm = grok.match(line);
-            Map<String, Object> map = gm.capture();
+            Map<String, Entity> map = gm.capture();
             assertNotNull(gm.toJson());
             assertNotEquals("{\"Error\":\"Error\"}", gm.toJson());
             assertEquals(((Entity)map.get("IP")).value, line);
@@ -360,7 +360,7 @@ public class GrokTest {
         int i = 0;
         for (String month : months) {
             Match m = grok.match(month);
-            Map<String, Object> map = m.capture();
+            Map<String, Entity> map = m.capture();
             assertNotNull(map);
             assertEquals(((Entity)map.get("MONTH")).value, months.get(i));
             i++;
@@ -391,7 +391,7 @@ public class GrokTest {
         int i = 0;
         for (String time : times) {
             Match m = grok.match(time);
-            Map<String, Object> map = m.capture();
+            Map<String, Entity> map = m.capture();
             assertNotNull(map);
             assertEquals(((Entity)map.get("TIMESTAMP_ISO8601")).value, times.get(i));
             i++;
@@ -435,7 +435,7 @@ public class GrokTest {
         int i = 0;
         for (String uri : uris) {
             Match m = grok.match(uri);
-            Map<String, Object> map = m.capture();
+            Map<String, Entity> map = m.capture();
             assertNotNull(map);
             assertEquals(((Entity)map.get("URI")).value, uris.get(i));
             assertNotNull(map.get("URIPROTO"));
@@ -458,7 +458,7 @@ public class GrokTest {
         int i = 0;
         for (String uri : uris) {
             Match m = grok.match(uri);
-            Map<String, Object> map = m.capture();
+            Map<String, Entity> map = m.capture();
             assertNotNull(map);
             if (i == 2) {
                 assertEquals(Collections.EMPTY_MAP, map);
@@ -477,7 +477,7 @@ public class GrokTest {
 
         String text = "<< barfoobarfoo >>";
         Match match = g.match(text);
-        Map<String, Object> map = match.capture();
+        Map<String, Entity> map = match.capture();
         assertEquals(
             "<< barfoobarfoo >>[0,18]",
                 map.get("text").toString());
@@ -507,7 +507,7 @@ public class GrokTest {
 
     private void assertMatches(String description, Grok grok, String text) {
         Match match = grok.match(text);
-        Map<String, Object> map = match.capture();
+        Map<String, Entity> map = match.capture();
         assertEquals(format("%s: unable to parse '%s'", description, text),
                 text,
             ((Entity) map.get("text")).value);
@@ -567,11 +567,11 @@ public class GrokTest {
         assertNull(grok.groupTypes.get("host"));
 
        Match match = grok.match("07/Mar/2004:16:45:56 -0800 test 64.242.88.10:8080");
-       Map<String, Object> result = match.capture();
-       assertEquals("test", result.get("username"));
+       Map<String, Entity> result = match.capture();
+       assertEquals("test[27,31]", result.get("username").toString());
        assertEquals("64.242.88.10[32,44]", result.get("host").toString());
-       assertEquals(8080, result.get("port"));
-       assertTrue(result.get("timestamp") instanceof Instant);
+       assertEquals(8080, result.get("port").value);
+       assertTrue(result.get("timestamp").value instanceof Instant);
     }
 
     @Test
@@ -580,20 +580,20 @@ public class GrokTest {
         String date = "03/19/2018 14:11:00";
         DateTimeFormatter dtf = DateTimeFormatter.ofPattern("MM/dd/yyyy HH:mm:ss");
         Grok grok = compiler.compile("%{DATESTAMP:timestamp;date;MM/dd/yyyy HH:mm:ss}", true);
-        Instant instant = (Instant) grok.match(date).capture().get("timestamp");
+        Instant instant = (Instant) grok.match(date).capture().get("timestamp").value;
         assertEquals(ZonedDateTime.parse(date, dtf.withZone(ZoneOffset.UTC)).toInstant(), instant);
 
         // set default timezone to PST
         ZoneId PST = ZoneId.of("PST", ZoneId.SHORT_IDS);
         grok = compiler.compile("%{DATESTAMP:timestamp;date;MM/dd/yyyy HH:mm:ss}", PST, true);
-        instant = (Instant) grok.match(date).capture().get("timestamp");
+        instant = (Instant) grok.match(date).capture().get("timestamp").value;
         assertEquals(ZonedDateTime.parse(date, dtf.withZone(PST)).toInstant(), instant);
 
         // when timestamp has timezone, use it instead of the default.
         String dateWithTimeZone = "07/Mar/2004:16:45:56 +0800";
         dtf = DateTimeFormatter.ofPattern("dd/MMM/yyyy:HH:mm:ss Z");
         grok = compiler.compile("%{HTTPDATE:timestamp;date;dd/MMM/yyyy:HH:mm:ss Z}", PST, true);
-        instant = (Instant) grok.match(dateWithTimeZone).capture().get("timestamp");
+        instant = (Instant) grok.match(dateWithTimeZone).capture().get("timestamp").value;
         assertEquals(ZonedDateTime.parse(dateWithTimeZone, dtf.withZone(ZoneOffset.ofHours(8))).toInstant(), instant);
     }
 

--- a/src/test/java/io/thekraken/grok/api/GrokTest.java
+++ b/src/test/java/io/thekraken/grok/api/GrokTest.java
@@ -77,23 +77,23 @@ public class GrokTest {
         Grok staticGrok = compiler.compile("%{USERNAME}");
         Match gm = staticGrok.match("root");
         Map<String, Object> map = gm.capture();
-        assertEquals("{USERNAME=root}", map.toString());
+        assertEquals("{USERNAME=root[0,4]}", map.toString());
 
         gm = staticGrok.match("r00t");
         map = gm.capture();
-        assertEquals("{USERNAME=r00t}", map.toString());
+        assertEquals("{USERNAME=r00t[0,4]}", map.toString());
 
         gm = staticGrok.match("guest");
         map = gm.capture();
-        assertEquals("{USERNAME=guest}", map.toString());
+        assertEquals("{USERNAME=guest[0,5]}", map.toString());
 
         gm = staticGrok.match("guest1234");
         map = gm.capture();
-        assertEquals("{USERNAME=guest1234}", map.toString());
+        assertEquals("{USERNAME=guest1234[0,9]}", map.toString());
 
         gm = staticGrok.match("john doe");
         map = gm.capture();
-        assertEquals("{USERNAME=john}", map.toString());
+        assertEquals("{USERNAME=john[0,4]}", map.toString());
     }
 
 
@@ -103,23 +103,23 @@ public class GrokTest {
 
         Match gm = g.match("root");
         Map<String, Object> map = gm.capture();
-        assertEquals("{USERNAME=root}", map.toString());
+        assertEquals("{USERNAME=root[0,4]}", map.toString());
 
         gm = g.match("r00t");
         map = gm.capture();
-        assertEquals("{USERNAME=r00t}", map.toString());
+        assertEquals("{USERNAME=r00t[0,4]}", map.toString());
 
         gm = g.match("guest");
         map = gm.capture();
-        assertEquals("{USERNAME=guest}", map.toString());
+        assertEquals("{USERNAME=guest[0,5]}", map.toString());
 
         gm = g.match("guest1234");
         map = gm.capture();
-        assertEquals("{USERNAME=guest1234}", map.toString());
+        assertEquals("{USERNAME=guest1234[0,9]}", map.toString());
 
         gm = g.match("john doe");
         map = gm.capture();
-        assertEquals("{USERNAME=john}", map.toString());
+        assertEquals("{USERNAME=john[0,4]}", map.toString());
     }
 
     @Test
@@ -128,23 +128,23 @@ public class GrokTest {
 
         Match gm = g.match("root");
         Map<String, Object> map = gm.capture();
-        assertEquals("{USER=root}", map.toString());
+        assertEquals("{USER=root[0,4]}", map.toString());
 
         gm = g.match("r00t");
         map = gm.capture();
-        assertEquals("{USER=r00t}", map.toString());
+        assertEquals("{USER=r00t[0,4]}", map.toString());
 
         gm = g.match("guest");
         map = gm.capture();
-        assertEquals("{USER=guest}", map.toString());
+        assertEquals("{USER=guest[0,5]}", map.toString());
 
         gm = g.match("guest1234");
         map = gm.capture();
-        assertEquals("{USER=guest1234}", map.toString());
+        assertEquals("{USER=guest1234[0,9]}", map.toString());
 
         gm = g.match("john doe");
         map = gm.capture();
-        assertEquals("{USER=john}", map.toString());
+        assertEquals("{USER=john[0,4]}", map.toString());
     }
 
     @Test
@@ -153,7 +153,7 @@ public class GrokTest {
 
         Match gm = g.match("-42");
         Map<String, Object> map = gm.capture();
-        assertEquals("{NUMBER=-42}", map.toString());
+        assertEquals("{NUMBER=-42[0,3]}", map.toString());
 
     }
 
@@ -163,11 +163,11 @@ public class GrokTest {
 
         Match gm = g.match("a");
         Map<String, Object> map = gm.capture();
-        assertEquals("{WORD=a}", map.toString());
+        assertEquals("{WORD=a[0,1]}", map.toString());
 
         gm = g.match("abc");
         map = gm.capture();
-        assertEquals("{WORD=abc}", map.toString());
+        assertEquals("{WORD=abc[0,3]}", map.toString());
 
     }
 
@@ -177,7 +177,7 @@ public class GrokTest {
 
         Match gm = g.match("abc dc");
         Map<String, Object> map = gm.capture();
-        assertEquals("{SPACE=}", map.toString());
+        assertEquals("{SPACE=[0,0]}", map.toString());
 
     }
 
@@ -187,7 +187,7 @@ public class GrokTest {
 
         Match gm = g.match("Something costs $55.4!");
         Map<String, Object> map = gm.capture();
-        assertEquals("{NUMBER=55.4}", map.toString());
+        assertEquals("{NUMBER=55.4[17,21]}", map.toString());
 
     }
 
@@ -197,7 +197,7 @@ public class GrokTest {
 
         Match gm = g.match("abc dc");
         Map<String, Object> map = gm.capture();
-        assertEquals("{NOTSPACE=abc}", map.toString());
+        assertEquals("{NOTSPACE=abc[0,3]}", map.toString());
 
     }
 
@@ -207,7 +207,7 @@ public class GrokTest {
 
         Match gm = g.match("\"abc dc\"");
         Map<String, Object> map = gm.capture();
-        assertEquals("{text=abc dc}", map.toString());
+        assertEquals("{text=abc dc[1,7]}", map.toString());
     }
 
     @Test
@@ -216,15 +216,15 @@ public class GrokTest {
 
         Match gm = g.match("61243740-4786-11e3-86a7-0002a5d5c51b");
         Map<String, Object> map = gm.capture();
-        assertEquals("{UUID=61243740-4786-11e3-86a7-0002a5d5c51b}", map.toString());
+        assertEquals("{UUID=61243740-4786-11e3-86a7-0002a5d5c51b[0,36]}", map.toString());
 
         gm = g.match("7F8C7CB0-4786-11E3-8F96-0800200C9A66");
         map = gm.capture();
-        assertEquals("{UUID=7F8C7CB0-4786-11E3-8F96-0800200C9A66}", map.toString());
+        assertEquals("{UUID=7F8C7CB0-4786-11E3-8F96-0800200C9A66[0,36]}", map.toString());
 
         gm = g.match("03A8413C-F604-4D21-8F4D-24B19D98B5A7");
         map = gm.capture();
-        assertEquals("{UUID=03A8413C-F604-4D21-8F4D-24B19D98B5A7}", map.toString());
+        assertEquals("{UUID=03A8413C-F604-4D21-8F4D-24B19D98B5A7[0,36]}", map.toString());
 
     }
 
@@ -234,7 +234,7 @@ public class GrokTest {
 
         Match gm = g.match("5E:FF:56:A2:AF:15");
         Map<String, Object> map = gm.capture();
-        assertEquals("{MAC=5E:FF:56:A2:AF:15}", map.toString());
+        assertEquals("{MAC=5E:FF:56:A2:AF:15[0,17]}", map.toString());
 
     }
 
@@ -244,11 +244,11 @@ public class GrokTest {
 
         Match gm = g.match("www.google.fr");
         Map<String, Object> map = gm.capture();
-        assertEquals("{IPORHOST=www.google.fr}", map.toString());
+        assertEquals("{IPORHOST=www.google.fr[0,13]}", map.toString());
 
         gm = g.match("www.google.com");
         map = gm.capture();
-        assertEquals("{IPORHOST=www.google.com}", map.toString());
+        assertEquals("{IPORHOST=www.google.com[0,14]}", map.toString());
     }
 
     @Test
@@ -257,10 +257,9 @@ public class GrokTest {
 
         Match gm = g.match("www.google.fr:80");
         Map<String, Object> map = gm.capture();
-        assertEquals(ImmutableMap.of(
-            "HOSTPORT", "www.google.fr:80",
-            "IPORHOST", "www.google.fr",
-            "PORT", "80"), map);
+        assertEquals("www.google.fr:80[0,16]", map.get("HOSTPORT").toString());
+        assertEquals("www.google.fr[0,13]", map.get("IPORHOST").toString());
+        assertEquals("80[14,16]", map.get("PORT").toString());
     }
 
     @Test
@@ -272,12 +271,12 @@ public class GrokTest {
         Map<String, Object> map = gm.capture();
         assertNotNull(gm.toJson());
         assertEquals(
-                map.get("agent").toString(),
-                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.152 Safari/537.22");
-        assertEquals(map.get("clientip").toString(), "112.169.19.192");
-        assertEquals(map.get("httpversion").toString(), "1.1");
-        assertEquals(map.get("timestamp").toString(), "06/Mar/2013:01:36:30 +0900");
-        assertEquals(map.get("TIME").toString(), "01:36:30");
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.152 Safari/537.22[80,200]",
+            map.get("agent").toString());
+        assertEquals(map.get("clientip").toString(), "112.169.19.192[0,14]");
+        assertEquals(map.get("httpversion").toString(), "1.1[60,63]");
+        assertEquals(map.get("timestamp").toString(), "06/Mar/2013:01:36:30 +0900[20,46]");
+        assertEquals(map.get("TIME").toString(), "01:36:30[32,40]");
 
         gm =
                 g.match("112.169.19.192 - - [06/Mar/2013:01:36:30 +0900] \"GET /wp-content/plugins/easy-table/themes/default/style.css?ver=1.0 HTTP/1.1\" 304 - \"http://www.nflabs.com/\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.152 Safari/537.22\"");
@@ -286,12 +285,12 @@ public class GrokTest {
         // System.out.println(gm.toJson());
         assertEquals(
                 map.get("agent").toString(),
-                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.152 Safari/537.22");
-        assertEquals(map.get("clientip").toString(), "112.169.19.192");
-        assertEquals(map.get("httpversion").toString(), "1.1");
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.152 Safari/537.22[159,279]");
+        assertEquals(map.get("clientip").toString(), "112.169.19.192[0,14]");
+        assertEquals(map.get("httpversion").toString(), "1.1[122,125]");
         assertEquals(map.get("request").toString(),
-                "/wp-content/plugins/easy-table/themes/default/style.css?ver=1.0");
-        assertEquals(map.get("TIME").toString(), "01:36:30");
+                "/wp-content/plugins/easy-table/themes/default/style.css?ver=1.0[53,116]");
+        assertEquals(map.get("TIME").toString(), "01:36:30[32,40]");
 
         // assertEquals("{HOSTPORT=www.google.fr:80, IPORHOST=www.google.fr, PORT=80}",
         // map.toString());
@@ -328,7 +327,7 @@ public class GrokTest {
             Match m = grok.match(day);
             Map<String, Object> map = m.capture();
             assertNotNull(map);
-            assertEquals(map.get("DAY"), days.get(i));
+            assertEquals(((Entity) map.get("DAY")).value, days.get(i));
             i++;
         }
     }
@@ -345,7 +344,7 @@ public class GrokTest {
             Map<String, Object> map = gm.capture();
             assertNotNull(gm.toJson());
             assertNotEquals("{\"Error\":\"Error\"}", gm.toJson());
-            assertEquals(map.get("IP"), line);
+            assertEquals(((Entity)map.get("IP")).value, line);
         }
     }
 
@@ -363,7 +362,7 @@ public class GrokTest {
             Match m = grok.match(month);
             Map<String, Object> map = m.capture();
             assertNotNull(map);
-            assertEquals(map.get("MONTH"), months.get(i));
+            assertEquals(((Entity)map.get("MONTH")).value, months.get(i));
             i++;
         }
     }
@@ -394,7 +393,7 @@ public class GrokTest {
             Match m = grok.match(time);
             Map<String, Object> map = m.capture();
             assertNotNull(map);
-            assertEquals(map.get("TIMESTAMP_ISO8601"), times.get(i));
+            assertEquals(((Entity)map.get("TIMESTAMP_ISO8601")).value, times.get(i));
             i++;
         }
     }
@@ -438,7 +437,7 @@ public class GrokTest {
             Match m = grok.match(uri);
             Map<String, Object> map = m.capture();
             assertNotNull(map);
-            assertEquals(map.get("URI"), uris.get(i));
+            assertEquals(((Entity)map.get("URI")).value, uris.get(i));
             assertNotNull(map.get("URIPROTO"));
             i++;
         }
@@ -479,9 +478,9 @@ public class GrokTest {
         String text = "<< barfoobarfoo >>";
         Match match = g.match(text);
         Map<String, Object> map = match.capture();
-        assertEquals("unable to parse: " + text,
-                text,
-                map.get("text"));
+        assertEquals(
+            "<< barfoobarfoo >>[0,18]",
+                map.get("text").toString());
     }
 
     @Test
@@ -511,7 +510,7 @@ public class GrokTest {
         Map<String, Object> map = match.capture();
         assertEquals(format("%s: unable to parse '%s'", description, text),
                 text,
-                map.get("text"));
+            ((Entity) map.get("text")).value);
     }
 
     @Test
@@ -570,7 +569,7 @@ public class GrokTest {
        Match match = grok.match("07/Mar/2004:16:45:56 -0800 test 64.242.88.10:8080");
        Map<String, Object> result = match.capture();
        assertEquals("test", result.get("username"));
-       assertEquals("64.242.88.10", result.get("host"));
+       assertEquals("64.242.88.10[32,44]", result.get("host").toString());
        assertEquals(8080, result.get("port"));
        assertTrue(result.get("timestamp") instanceof Instant);
     }
@@ -602,7 +601,7 @@ public class GrokTest {
     public void testQuotedNamedGroup() throws Exception {
         Grok grok = compiler.compile("(?'kafka.log.trace.full'.*)", true);
         Match match = grok.match("this is some trace");
-        assertEquals("this is some trace", match.capture().get("kafka.log.trace.full"));
+        assertEquals("this is some trace[0,18]", match.capture().get("kafka.log.trace.full").toString());
     }
 
     @Test

--- a/src/test/java/io/thekraken/grok/api/MessagesTest.java
+++ b/src/test/java/io/thekraken/grok/api/MessagesTest.java
@@ -29,7 +29,7 @@ public class MessagesTest {
         System.out.println("Starting test with linux messages log -- may take a while");
         while ((line = br.readLine()) != null) {
             Match gm = g.match(line);
-            Map<String, Object> map = gm.capture();
+            Map<String, Entity> map = gm.capture();
             assertNotNull(gm.toJson());
             assertNotEquals("{\"Error\":\"Error\"}", gm.toJson());
         }

--- a/src/test/java/io/thekraken/grok/api/TestPerformance.java
+++ b/src/test/java/io/thekraken/grok/api/TestPerformance.java
@@ -17,7 +17,7 @@ public class TestPerformance {
     long start = System.currentTimeMillis();
     for (int i=0; i < 1000000; i++) {
       Match match = grok.match(input);
-      Map<String, Object> map = match.capture();
+      Map<String, Entity> map = match.capture();
     }
     long end = System.currentTimeMillis();
     System.out.println("took: " + (end-start) + " millis");


### PR DESCRIPTION
`Match.capture()` now returns `Map<String, Entity>` where `Entity` consists of `value` String and `start/end` int offsets. When there are multiple matches, `Entity` store them in `additionalEntities`.
