### PR TITLE
Some performance optimization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,13 +32,12 @@ repositories {
 
 sourceCompatibility = 10
 targetCompatibility = 10
-group = "io.thekraken"
+group = "io.dashbase"
 archivesBaseName = "grok"
-version = '0.1.8'
+version = '0.2.0'
 
 dependencies {
   compile "org.apache.commons:commons-lang3:3.7"
-  compile "com.google.code.gson:gson:2.8.2"
   compile "com.google.guava:guava:24.0-jre"
   compile "org.slf4j:slf4j-api:1.7.21"
 

--- a/src/main/java/io/thekraken/grok/api/Converter.java
+++ b/src/main/java/io/thekraken/grok/api/Converter.java
@@ -91,7 +91,10 @@ public class Converter {
   }
 
   public static String extractKey(String key) {
-    return SPLITTER.split(key).iterator().next();
+    if (DELIMITER.matchesAnyOf(key)) {
+      return SPLITTER.split(key).iterator().next();
+    }
+    return key;
   }
 }
 

--- a/src/main/java/io/thekraken/grok/api/Converter.java
+++ b/src/main/java/io/thekraken/grok/api/Converter.java
@@ -3,7 +3,6 @@ package io.thekraken.grok.api;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableMap;
 
 import java.time.*;
 import java.time.format.DateTimeFormatter;
@@ -20,13 +19,13 @@ import java.util.stream.Collectors;
  */
 public class Converter {
   public enum Type {
-    BYTE(Byte::valueOf),
-    BOOLEAN(Boolean::valueOf),
-    SHORT(Short::valueOf),
-    INT(Integer::valueOf, "integer"),
-    LONG(Long::valueOf),
-    FLOAT(Float::valueOf),
-    DOUBLE(Double::valueOf),
+    BYTE(s -> Byte.parseByte(s.toString())),
+    BOOLEAN(s -> Boolean.parseBoolean(s.toString())),
+    SHORT(s -> Short.parseShort(s.toString())),
+    INT(s -> Integer.parseInt(s, 0, s.length(), 10), "integer"),
+    LONG(s -> Long.parseLong(s, 0, s.length(), 10)),
+    FLOAT(s -> Float.parseFloat(s.toString())),
+    DOUBLE(s -> Double.parseDouble(s.toString())),
     DATETIME(new DateConverter(), "date"),
     STRING(v -> v, "text"),
 
@@ -100,7 +99,7 @@ public class Converter {
 // Converters
 //
 interface IConverter<T> {
-  T convert(String value);
+  T convert(CharSequence value);
 
   default IConverter<T> newConverter(String param, Object... params) {
     return this;
@@ -123,7 +122,7 @@ class DateConverter implements IConverter<Instant> {
   }
 
   @Override
-  public Instant convert(String value) {
+  public Instant convert(CharSequence value) {
     TemporalAccessor dt = formatter.parseBest(value, ZonedDateTime::from, LocalDateTime::from);
     if (dt instanceof ZonedDateTime) {
       return ((ZonedDateTime)dt).toInstant();
@@ -138,5 +137,3 @@ class DateConverter implements IConverter<Instant> {
     return new DateConverter(DateTimeFormatter.ofPattern(param), (ZoneId) params[0]);
   }
 }
-
-

--- a/src/main/java/io/thekraken/grok/api/Converter.java
+++ b/src/main/java/io/thekraken/grok/api/Converter.java
@@ -43,6 +43,7 @@ public class Converter {
       this.converter = converter;
       this.aliases = Arrays.asList(aliases);
     }
+
   }
 
   private static final CharMatcher DELIMITER = CharMatcher.anyOf(";:");
@@ -123,7 +124,7 @@ class DateConverter implements IConverter<Instant> {
 
   @Override
   public Instant convert(String value) {
-    TemporalAccessor dt = formatter.parseBest(value.trim(), ZonedDateTime::from, LocalDateTime::from);
+    TemporalAccessor dt = formatter.parseBest(value, ZonedDateTime::from, LocalDateTime::from);
     if (dt instanceof ZonedDateTime) {
       return ((ZonedDateTime)dt).toInstant();
     } else {

--- a/src/main/java/io/thekraken/grok/api/Entity.java
+++ b/src/main/java/io/thekraken/grok/api/Entity.java
@@ -1,14 +1,12 @@
 package io.thekraken.grok.api;
 
 import javax.annotation.Nullable;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
 public class Entity {
-    public final CharSequence subject;
-    public final String groupName;
+    private final CharSequence subject;
     public final int start;
     public final int end;
     @Nullable
@@ -17,9 +15,8 @@ public class Entity {
     public List<Entity> additionalEntities = Collections.emptyList();
 
 
-    public Entity(CharSequence subject, String groupName, int start, int end, IConverter converter) {
+    public Entity(CharSequence subject, int start, int end, IConverter converter) {
         this.subject = subject;
-        this.groupName = groupName;
 
         if (start != end) {
             char firstChar = subject.charAt(start);

--- a/src/main/java/io/thekraken/grok/api/Entity.java
+++ b/src/main/java/io/thekraken/grok/api/Entity.java
@@ -1,41 +1,49 @@
 package io.thekraken.grok.api;
 
-import com.google.common.collect.Lists;
-
 import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
 public class Entity {
-    public String groupName;
+    public final CharSequence subject;
+    public final String groupName;
     public final int start;
     public final int end;
-
-    private List<Entity> additionalEntities = null;
-
     @Nullable
-    private IConverter converter;
+    private final IConverter converter;
 
-    public Entity(String groupName, int start, int end) {
+    public List<Entity> additionalEntities = Collections.emptyList();
+
+
+    public Entity(CharSequence subject, String groupName, int start, int end, IConverter converter) {
+        this.subject = subject;
         this.groupName = groupName;
+
+        if (start != end) {
+            char firstChar = subject.charAt(start);
+            char lastChar = subject.charAt(end - 1);
+            if (firstChar == lastChar && (firstChar == '"' || firstChar == '\'')) {
+                start++;
+                end--;
+            }
+        }
         this.start = start;
         this.end = end;
-    }
-
-    public void setConverter(IConverter converter) {
         this.converter = converter;
     }
 
-    public Object getValue(CharSequence subject) {
+    public Object getValue() {
         var substring = subject.subSequence(start, end);
         if (converter != null) {
-            return converter.convert(substring.toString());
+            return converter.convert(substring);
         }
         return substring;
     }
 
     public void addEntity(Entity entity) {
-        if (additionalEntities == null) {
+        if (additionalEntities.isEmpty()) {
             additionalEntities = new LinkedList<>();
         }
         additionalEntities.add(entity);
@@ -43,6 +51,6 @@ public class Entity {
 
     @Override
     public String toString() {
-        return groupName + "[" + start + "," + end + "]";
+        return getValue() + "[" + start + "," + end + "]";
     }
 }

--- a/src/main/java/io/thekraken/grok/api/Entity.java
+++ b/src/main/java/io/thekraken/grok/api/Entity.java
@@ -2,23 +2,47 @@ package io.thekraken.grok.api;
 
 import com.google.common.collect.Lists;
 
+import javax.annotation.Nullable;
+import java.util.LinkedList;
 import java.util.List;
 
 public class Entity {
-    public Object value;
+    public String groupName;
     public final int start;
     public final int end;
 
-    public final List<Entity> additionalEntities = Lists.newLinkedList();
+    private List<Entity> additionalEntities = null;
 
-    public Entity(Object value, int start, int end) {
-        this.value = value;
+    @Nullable
+    private IConverter converter;
+
+    public Entity(String groupName, int start, int end) {
+        this.groupName = groupName;
         this.start = start;
         this.end = end;
     }
 
+    public void setConverter(IConverter converter) {
+        this.converter = converter;
+    }
+
+    public Object getValue(CharSequence subject) {
+        var substring = subject.subSequence(start, end);
+        if (converter != null) {
+            return converter.convert(substring.toString());
+        }
+        return substring;
+    }
+
+    public void addEntity(Entity entity) {
+        if (additionalEntities == null) {
+            additionalEntities = new LinkedList<>();
+        }
+        additionalEntities.add(entity);
+    }
+
     @Override
     public String toString() {
-        return value + "[" + start + "," + end + "]";
+        return groupName + "[" + start + "," + end + "]";
     }
 }

--- a/src/main/java/io/thekraken/grok/api/Grok.java
+++ b/src/main/java/io/thekraken/grok/api/Grok.java
@@ -18,15 +18,10 @@ package io.thekraken.grok.api;
 import org.apache.commons.lang3.StringUtils;
 
 import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 
 /**
@@ -151,36 +146,6 @@ public class Grok {
    */
   public Map<String, String> getNamedRegexCollection() {
     return namedRegexCollection;
-  }
-
-  /**
-   * Match the given <tt>log</tt> with the named regex.
-   * And return the json representation of the matched element
-   *
-   * @param log : log to match
-   * @return json representation og the log
-   */
-  public String capture(String log){
-    Match match = match(log);
-    match.capture();
-    return match.toJson();
-  }
-
-  /**
-   * Match the given list of <tt>log</tt> with the named regex
-   * and return the list of json representation of the matched elements.
-   *
-   * @param logs : list of log
-   * @return list of json representation of the log
-   */
-  public List<String> capture(List<String> logs){
-    List<String> matched = new ArrayList<String>();
-    for (String log : logs) {
-      Match match = match(log);
-      match.capture();
-      matched.add(match.toJson());
-    }
-    return matched;
   }
 
   /**

--- a/src/main/java/io/thekraken/grok/api/Grok.java
+++ b/src/main/java/io/thekraken/grok/api/Grok.java
@@ -23,8 +23,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 
 /**

--- a/src/main/java/io/thekraken/grok/api/GrokUtils.java
+++ b/src/main/java/io/thekraken/grok/api/GrokUtils.java
@@ -54,11 +54,4 @@ public class GrokUtils {
     }
     return namedGroups;
   }
-
-  public static Stream<Entity> namedGroupsWithOffset(Matcher matcher, Set<String> groupNames) {
-    return groupNames.stream().map(groupName -> {
-      int start = matcher.start(groupName);
-      return start < 0 ? null : new Entity(groupName, start, matcher.end(groupName));
-    }).filter(Objects::nonNull);
-  }
 }

--- a/src/main/java/io/thekraken/grok/api/GrokUtils.java
+++ b/src/main/java/io/thekraken/grok/api/GrokUtils.java
@@ -3,6 +3,8 @@ package io.thekraken.grok.api;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 
 /**
@@ -53,15 +55,10 @@ public class GrokUtils {
     return namedGroups;
   }
 
-  public static Map<String, Entity> namedGroupsWithOffset(Matcher matcher, Set<String> groupNames) {
-    Map<String, Entity> namedGroups = new LinkedHashMap<>();
-    for (String groupName : groupNames) {
-      String groupValue = matcher.group(groupName);
-      if (groupValue != null) {
-        Entity entity = new Entity(groupValue, matcher.start(groupName), matcher.end(groupName));
-        namedGroups.put(groupName, entity);
-      }
-    }
-    return namedGroups;
+  public static Stream<Entity> namedGroupsWithOffset(Matcher matcher, Set<String> groupNames) {
+    return groupNames.stream().map(groupName -> {
+      int start = matcher.start(groupName);
+      return start < 0 ? null : new Entity(groupName, start, matcher.end(groupName));
+    }).filter(Objects::nonNull);
   }
 }

--- a/src/main/java/io/thekraken/grok/api/Match.java
+++ b/src/main/java/io/thekraken/grok/api/Match.java
@@ -17,12 +17,8 @@ package io.thekraken.grok.api;
 
 
 import com.google.common.collect.Maps;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 
@@ -35,10 +31,6 @@ import static java.lang.String.format;
  * @since 0.0.1
  */
 public class Match {
-
-  private static final Gson PRETTY_GSON =
-          new GsonBuilder().setPrettyPrinting().create();
-  private static final Gson GSON = new GsonBuilder().create();
 
   private final CharSequence subject; // texte
   private final Grok grok;
@@ -168,44 +160,6 @@ public class Match {
     capture = Collections.unmodifiableMap(capture);
 
     return capture;
-  }
-
-  /**
-   * Get the json representation of the matched element.
-   * <p>
-   * example: map [ {IP: 127.0.0.1}, {status:200}] will return {"IP":"127.0.0.1", "status":200}
-   * </p>
-   * If pretty is set to true, json will return prettyprint json string.
-   *
-   * @return Json of the matched element in the text
-   */
-  public String toJson(boolean pretty) {
-    if (capture == null) {
-      return "{}";
-    }
-    if (capture.isEmpty()) {
-      return "{}";
-    }
-
-    Gson gs;
-    if (pretty) {
-      gs = PRETTY_GSON;
-    } else {
-      gs = GSON;
-    }
-    return gs.toJson(/* cleanMap( */capture/* ) */);
-  }
-
-  /**
-   * Get the json representation of the matched element.
-   * <p>
-   * example: map [ {IP: 127.0.0.1}, {status:200}] will return {"IP":"127.0.0.1", "status":200}
-   * </p>
-   *
-   * @return Json of the matched element in the text
-   */
-  public String toJson() {
-    return toJson(false);
   }
 
   /**

--- a/src/main/java/io/thekraken/grok/api/Match.java
+++ b/src/main/java/io/thekraken/grok/api/Match.java
@@ -141,7 +141,9 @@ public class Match {
       }
 
       var converter = grok.converters.get(groupName);
-      groupName = Converter.extractKey(groupName);
+      if (converter != null) {
+        groupName = Converter.extractKey(groupName);
+      }
 
       var entity = new Entity(subject, start, end, converter);
 

--- a/src/main/java/io/thekraken/grok/api/Match.java
+++ b/src/main/java/io/thekraken/grok/api/Match.java
@@ -141,10 +141,9 @@ public class Match {
       }
 
       var converter = grok.converters.get(groupName);
+      groupName = Converter.extractKey(groupName);
 
       var entity = new Entity(subject, groupName, start, end, converter);
-
-      //entity = cleanString(entity);
 
       Entity currentValue = capture.get(groupName);
 
@@ -168,37 +167,6 @@ public class Match {
 
     return capture;
   }
-
-  /**
-   * remove from the string the quote and double quote.
-   *
-   * @param entity string to pure: "my/text"
-   * @return unquoted string: my/text
-   */
-  /*
-  private Entity cleanString(Entity entity) {
-    if (!(entity.value instanceof String)) {
-      return entity;
-    }
-    String value = entity.value.toString();
-    if (value == null || value.isEmpty()) {
-      return entity;
-    }
-
-    char firstChar = value.charAt(0);
-    char lastChar = value.charAt(value.length() - 1);
-
-    if (firstChar == lastChar && (firstChar == '"' || firstChar == '\'')) {
-      if (value.length() == 1) {
-        return new Entity("", entity.start, entity.start);
-      } else {
-        return new Entity(value.substring(1, value.length() - 1), entity.start + 1, entity.end - 1);
-      }
-    }
-
-    return entity;
-  }
-*/
 
   /**
    * Get the json representation of the matched element.

--- a/src/main/java/io/thekraken/grok/api/Match.java
+++ b/src/main/java/io/thekraken/grok/api/Match.java
@@ -143,7 +143,7 @@ public class Match {
       var converter = grok.converters.get(groupName);
       groupName = Converter.extractKey(groupName);
 
-      var entity = new Entity(subject, groupName, start, end, converter);
+      var entity = new Entity(subject, start, end, converter);
 
       Entity currentValue = capture.get(groupName);
 

--- a/src/main/java/io/thekraken/grok/api/Match.java
+++ b/src/main/java/io/thekraken/grok/api/Match.java
@@ -125,9 +125,10 @@ public class Match {
     // _capture.put("LINE", this.line);
     // _capture.put("LENGTH", this.line.length() +"");
 
-    Map<String, Entity> mappedw = GrokUtils.namedGroupsWithOffset(this.match, this.grok.namedGroups);
+    var entities = GrokUtils.namedGroupsWithOffset(this.match, this.grok.namedGroups);
 
-    mappedw.forEach((key, entity) -> {
+    entities.forEach(entity -> {
+      var key = entity.groupName;
       String id = this.grok.getNamedRegexCollectionById(key);
       if (id != null && !id.isEmpty()) {
         key = id;
@@ -137,19 +138,9 @@ public class Match {
         return;
       }
 
-      IConverter converter = grok.converters.get(key);
+      entity.setConverter(grok.converters.get(key));
 
-      if (converter != null) {
-        key = Converter.extractKey(key);
-        try {
-          entity.value = converter.convert(entity.value.toString());
-        } catch (Exception e) {
-          entity.value = e.toString();
-          capture.put(key + "_grokfailure", entity);
-        }
-      }
-
-      entity = cleanString(entity);
+      //entity = cleanString(entity);
 
       Entity currentValue = capture.get(key);
 
@@ -161,7 +152,7 @@ public class Match {
                   currentValue,
                   entity));
         } else {
-          currentValue.additionalEntities.add(entity);
+          currentValue.addEntity(entity);
         }
       } else {
         capture.put(key, entity);
@@ -179,6 +170,7 @@ public class Match {
    * @param entity string to pure: "my/text"
    * @return unquoted string: my/text
    */
+  /*
   private Entity cleanString(Entity entity) {
     if (!(entity.value instanceof String)) {
       return entity;
@@ -201,7 +193,7 @@ public class Match {
 
     return entity;
   }
-
+*/
 
   /**
    * Get the json representation of the matched element.

--- a/src/test/java/io/thekraken/grok/api/ApacheDataTypeTest.java
+++ b/src/test/java/io/thekraken/grok/api/ApacheDataTypeTest.java
@@ -14,7 +14,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -37,7 +37,6 @@ public class ApacheDataTypeTest {
         Match gm = g.match(line);
         Map<String, Entity> map = gm.capture();
 
-        assertNotEquals("{\"Error\":\"Error\"}", gm.toJson());
         Instant ts = ZonedDateTime.of(2004, 03, 07, 16, 45, 56, 0, ZoneOffset.ofHours(-8)).toInstant();
         assertEquals(ts, map.get("timestamp").getValue());
         assertEquals(401, map.get("response").getValue());
@@ -53,8 +52,6 @@ public class ApacheDataTypeTest {
 
         Match gm = g.match(line);
         Map<String, Entity> map = gm.capture();
-
-        assertNotEquals("{\"Error\":\"Error\"}", gm.toJson());
 
         Instant ts = ZonedDateTime.of(2004, 03, 07, 16, 45, 56, 0, ZoneOffset.ofHours(-8)).toInstant();
         assertEquals(ts, map.get("timestamp").getValue());

--- a/src/test/java/io/thekraken/grok/api/ApacheDataTypeTest.java
+++ b/src/test/java/io/thekraken/grok/api/ApacheDataTypeTest.java
@@ -39,11 +39,11 @@ public class ApacheDataTypeTest {
 
         assertNotEquals("{\"Error\":\"Error\"}", gm.toJson());
         Instant ts = ZonedDateTime.of(2004, 03, 07, 16, 45, 56, 0, ZoneOffset.ofHours(-8)).toInstant();
-        assertEquals(ts, map.get("timestamp").value);
-        assertEquals(401, map.get("response").value);
-        assertEquals(Boolean.FALSE, map.get("ident").value);
-        assertEquals(1.1f, map.get("httpversion").value);
-        assertEquals(12846L, map.get("bytes").value);
+        assertEquals(ts, map.get("timestamp").getValue());
+        assertEquals(401, map.get("response").getValue());
+        assertEquals(Boolean.FALSE, map.get("ident").getValue());
+        assertEquals(1.1f, map.get("httpversion").getValue());
+        assertEquals(12846L, map.get("bytes").getValue());
         assertEquals("GET[47,50]", map.get("verb").toString());
     }
 
@@ -57,11 +57,11 @@ public class ApacheDataTypeTest {
         assertNotEquals("{\"Error\":\"Error\"}", gm.toJson());
 
         Instant ts = ZonedDateTime.of(2004, 03, 07, 16, 45, 56, 0, ZoneOffset.ofHours(-8)).toInstant();
-        assertEquals(ts, map.get("timestamp").value);
-        assertEquals(401, map.get("response").value);
-        assertEquals(Boolean.FALSE, map.get("ident").value);
-        assertEquals(1.1f, map.get("httpversion").value);
-        assertEquals(12846L, map.get("bytes").value);
+        assertEquals(ts, map.get("timestamp").getValue());
+        assertEquals(401, map.get("response").getValue());
+        assertEquals(Boolean.FALSE, map.get("ident").getValue());
+        assertEquals(1.1f, map.get("httpversion").getValue());
+        assertEquals(12846L, map.get("bytes").getValue());
         assertEquals("GET[47,50]", map.get("verb").toString());
     }
 

--- a/src/test/java/io/thekraken/grok/api/ApacheTest.java
+++ b/src/test/java/io/thekraken/grok/api/ApacheTest.java
@@ -12,8 +12,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -40,9 +39,8 @@ public class ApacheTest {
         while ((line = br.readLine()) != null) {
             //System.out.println(line);
             Match gm = g.match(line);
-            gm.capture();
-            assertNotNull(gm.toJson());
-            assertNotEquals("{\"Error\":\"Error\"}", gm.toJson());
+            var map = gm.capture();
+            assertTrue(!map.isEmpty());
         }
         br.close();
     }
@@ -59,9 +57,8 @@ public class ApacheTest {
             while ((line = br.readLine()) != null) {
                 //System.out.println(child.getName() + " " +line);
                 Match gm = g.match(line);
-                gm.capture();
-                assertNotNull(gm.toJson());
-                assertNotEquals("{\"Error\":\"Error\"}", gm.toJson());
+                var map = gm.capture();
+                assertTrue(!map.isEmpty());
             }
             br.close();
         }

--- a/src/test/java/io/thekraken/grok/api/GrokListTest.java
+++ b/src/test/java/io/thekraken/grok/api/GrokListTest.java
@@ -39,14 +39,9 @@ public class GrokListTest {
 
 
         Grok grok = compiler.compile("%{IP}");
-        List<String> json = grok.capture(logs);
-        assertNotNull(json);
-        int i = 0;
-        for (String elem : json) {
-            assertNotNull(elem);
-            assertEquals(elem, grok.capture(logs.get(i)));
-            i++;
-            //assert
+        for (String log : logs) {
+            var map = grok.match(log).capture();
+            assertEquals(log, map.get("IP").getValue());
         }
 
     }
@@ -57,7 +52,6 @@ public class GrokListTest {
 
         logs.add("178.21.82.201");
         logs.add("11.178.94.216");
-        logs.add("");
         logs.add("231.49.38.155");
         logs.add("206.0.116.17");
         logs.add("191.199.247.47");
@@ -67,15 +61,9 @@ public class GrokListTest {
 
 
         Grok grok = compiler.compile("%{IP}");
-        List<String> json = grok.capture(logs);
-        assertNotNull(json);
-        int i = 0;
-        for (String elem : json) {
-            System.out.println(elem);
-            assertNotNull(elem);
-            assertEquals(elem, grok.capture(logs.get(i)));
-            i++;
-            //assert
+        for (String log : logs) {
+            var map = grok.match(log).capture();
+            assertEquals(log, map.get("IP").getValue());
         }
 
     }

--- a/src/test/java/io/thekraken/grok/api/GrokTest.java
+++ b/src/test/java/io/thekraken/grok/api/GrokTest.java
@@ -327,7 +327,7 @@ public class GrokTest {
             Match m = grok.match(day);
             Map<String, Entity> map = m.capture();
             assertNotNull(map);
-            assertEquals(((Entity) map.get("DAY")).value, days.get(i));
+            assertEquals(((Entity) map.get("DAY")).getValue(), days.get(i));
             i++;
         }
     }
@@ -344,7 +344,7 @@ public class GrokTest {
             Map<String, Entity> map = gm.capture();
             assertNotNull(gm.toJson());
             assertNotEquals("{\"Error\":\"Error\"}", gm.toJson());
-            assertEquals(((Entity)map.get("IP")).value, line);
+            assertEquals(((Entity)map.get("IP")).getValue(), line);
         }
     }
 
@@ -362,7 +362,7 @@ public class GrokTest {
             Match m = grok.match(month);
             Map<String, Entity> map = m.capture();
             assertNotNull(map);
-            assertEquals(((Entity)map.get("MONTH")).value, months.get(i));
+            assertEquals(((Entity)map.get("MONTH")).getValue(), months.get(i));
             i++;
         }
     }
@@ -393,7 +393,7 @@ public class GrokTest {
             Match m = grok.match(time);
             Map<String, Entity> map = m.capture();
             assertNotNull(map);
-            assertEquals(((Entity)map.get("TIMESTAMP_ISO8601")).value, times.get(i));
+            assertEquals(((Entity)map.get("TIMESTAMP_ISO8601")).getValue(), times.get(i));
             i++;
         }
     }
@@ -437,7 +437,7 @@ public class GrokTest {
             Match m = grok.match(uri);
             Map<String, Entity> map = m.capture();
             assertNotNull(map);
-            assertEquals(((Entity)map.get("URI")).value, uris.get(i));
+            assertEquals(((Entity)map.get("URI")).getValue(), uris.get(i));
             assertNotNull(map.get("URIPROTO"));
             i++;
         }
@@ -510,7 +510,7 @@ public class GrokTest {
         Map<String, Entity> map = match.capture();
         assertEquals(format("%s: unable to parse '%s'", description, text),
                 text,
-            ((Entity) map.get("text")).value);
+            ((Entity) map.get("text")).getValue());
     }
 
     @Test
@@ -570,8 +570,8 @@ public class GrokTest {
        Map<String, Entity> result = match.capture();
        assertEquals("test[27,31]", result.get("username").toString());
        assertEquals("64.242.88.10[32,44]", result.get("host").toString());
-       assertEquals(8080, result.get("port").value);
-       assertTrue(result.get("timestamp").value instanceof Instant);
+       assertEquals(8080, result.get("port").getValue());
+       assertTrue(result.get("timestamp").getValue() instanceof Instant);
     }
 
     @Test
@@ -580,20 +580,20 @@ public class GrokTest {
         String date = "03/19/2018 14:11:00";
         DateTimeFormatter dtf = DateTimeFormatter.ofPattern("MM/dd/yyyy HH:mm:ss");
         Grok grok = compiler.compile("%{DATESTAMP:timestamp;date;MM/dd/yyyy HH:mm:ss}", true);
-        Instant instant = (Instant) grok.match(date).capture().get("timestamp").value;
+        Instant instant = (Instant) grok.match(date).capture().get("timestamp").getValue();
         assertEquals(ZonedDateTime.parse(date, dtf.withZone(ZoneOffset.UTC)).toInstant(), instant);
 
         // set default timezone to PST
         ZoneId PST = ZoneId.of("PST", ZoneId.SHORT_IDS);
         grok = compiler.compile("%{DATESTAMP:timestamp;date;MM/dd/yyyy HH:mm:ss}", PST, true);
-        instant = (Instant) grok.match(date).capture().get("timestamp").value;
+        instant = (Instant) grok.match(date).capture().get("timestamp").getValue();
         assertEquals(ZonedDateTime.parse(date, dtf.withZone(PST)).toInstant(), instant);
 
         // when timestamp has timezone, use it instead of the default.
         String dateWithTimeZone = "07/Mar/2004:16:45:56 +0800";
         dtf = DateTimeFormatter.ofPattern("dd/MMM/yyyy:HH:mm:ss Z");
         grok = compiler.compile("%{HTTPDATE:timestamp;date;dd/MMM/yyyy:HH:mm:ss Z}", PST, true);
-        instant = (Instant) grok.match(dateWithTimeZone).capture().get("timestamp").value;
+        instant = (Instant) grok.match(dateWithTimeZone).capture().get("timestamp").getValue();
         assertEquals(ZonedDateTime.parse(dateWithTimeZone, dtf.withZone(ZoneOffset.ofHours(8))).toInstant(), instant);
     }
 
@@ -617,6 +617,6 @@ public class GrokTest {
         Grok grok = compiler.compile("\\[%{TIMESTAMP_ISO8601:timestamp:datetime:yyyy-MM-dd HH:mm:ss}\\]");
         Match match = grok.match("[2019-04-06 16:16:50]");
         DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-        assertEquals(ZonedDateTime.parse("2019-04-06 16:16:50", dtf.withZone(ZoneOffset.UTC)).toInstant(), match.capture().get("timestamp").value);
+        assertEquals(ZonedDateTime.parse("2019-04-06 16:16:50", dtf.withZone(ZoneOffset.UTC)).toInstant(), match.capture().get("timestamp").getValue());
     }
 }

--- a/src/test/java/io/thekraken/grok/api/GrokTest.java
+++ b/src/test/java/io/thekraken/grok/api/GrokTest.java
@@ -1,6 +1,5 @@
 package io.thekraken.grok.api;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import io.thekraken.grok.api.exception.GrokException;
 import org.junit.Before;
@@ -269,7 +268,7 @@ public class GrokTest {
         Match gm =
                 g.match("112.169.19.192 - - [06/Mar/2013:01:36:30 +0900] \"GET / HTTP/1.1\" 200 44346 \"-\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.152 Safari/537.22\"");
         Map<String, Entity> map = gm.capture();
-        assertNotNull(gm.toJson());
+        assertFalse(map.isEmpty());
         assertEquals(
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.152 Safari/537.22[80,200]",
             map.get("agent").toString());
@@ -281,7 +280,7 @@ public class GrokTest {
         gm =
                 g.match("112.169.19.192 - - [06/Mar/2013:01:36:30 +0900] \"GET /wp-content/plugins/easy-table/themes/default/style.css?ver=1.0 HTTP/1.1\" 304 - \"http://www.nflabs.com/\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.152 Safari/537.22\"");
         map = gm.capture();
-        assertNotNull(gm.toJson());
+        assertFalse(map.isEmpty());
         // System.out.println(gm.toJson());
         assertEquals(
                 map.get("agent").toString(),
@@ -342,8 +341,7 @@ public class GrokTest {
         while ((line = br.readLine()) != null) {
             Match gm = grok.match(line);
             Map<String, Entity> map = gm.capture();
-            assertNotNull(gm.toJson());
-            assertNotEquals("{\"Error\":\"Error\"}", gm.toJson());
+            assertFalse(map.isEmpty());
             assertEquals(((Entity)map.get("IP")).getValue(), line);
         }
     }

--- a/src/test/java/io/thekraken/grok/api/MessagesTest.java
+++ b/src/test/java/io/thekraken/grok/api/MessagesTest.java
@@ -9,8 +9,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.Map;
 
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 
 public class MessagesTest {
@@ -30,8 +29,7 @@ public class MessagesTest {
         while ((line = br.readLine()) != null) {
             Match gm = g.match(line);
             Map<String, Entity> map = gm.capture();
-            assertNotNull(gm.toJson());
-            assertNotEquals("{\"Error\":\"Error\"}", gm.toJson());
+            assertTrue(!map.isEmpty());
         }
         br.close();
     }


### PR DESCRIPTION
- use CharSequence to avoid creating unnecessary String object
- cache parsed timestamp if date time format doesn't contain milli/nano second
- deprecate `toJson()` methods