### PR TITLE
capture newline chars in GREEDYDATA

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ sourceCompatibility = 10
 targetCompatibility = 10
 group = "io.dashbase"
 archivesBaseName = "grok"
-version = '0.2.0'
+version = '0.2.1'
 
 dependencies {
   compile "org.apache.commons:commons-lang3:3.7"

--- a/src/main/java/io/thekraken/grok/api/Grok.java
+++ b/src/main/java/io/thekraken/grok/api/Grok.java
@@ -87,7 +87,7 @@ public class Grok {
               ZoneId defaultTimeZone) {
     this.originalGrokPattern = pattern;
     this.namedRegex = namedRegex;
-    this.compiledNamedRegex = Pattern.compile(namedRegex);
+    this.compiledNamedRegex = Pattern.compile(namedRegex, Pattern.DOTALL);
     this.namedRegexCollection = namedRegexCollection;
     this.namedGroups = GrokUtils.getNameGroups(namedRegex);
     this.groupTypes = Converter.getGroupTypes(namedRegexCollection.values());

--- a/src/test/java/io/thekraken/grok/api/GrokTest.java
+++ b/src/test/java/io/thekraken/grok/api/GrokTest.java
@@ -617,4 +617,13 @@ public class GrokTest {
         DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
         assertEquals(ZonedDateTime.parse("2019-04-06 16:16:50", dtf.withZone(ZoneOffset.UTC)).toInstant(), match.capture().get("timestamp").getValue());
     }
+
+    @Test
+    public void testMultiline() throws Exception {
+        Grok grok = compiler.compile("\\[%{TIMESTAMP_ISO8601:timestamp:datetime:yyyy-MM-dd HH:mm:ss}\\] %{GREEDYDATA:message}");
+        Match match = grok.match("[2019-04-06 16:16:50] test\nabc\nxyz");
+        DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        assertEquals(ZonedDateTime.parse("2019-04-06 16:16:50", dtf.withZone(ZoneOffset.UTC)).toInstant(), match.capture().get("timestamp").getValue());
+        assertEquals("test\nabc\nxyz", match.capture().get("message").getValue());
+    }
 }


### PR DESCRIPTION
Enable `Pattern.DOTALL` option such that `GREEDYDATA` captures newline characters.