### PR TITLE
allow single quote in subname

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ sourceCompatibility = 10
 targetCompatibility = 10
 group = "io.dashbase"
 archivesBaseName = "grok"
-version = '0.2.1'
+version = '0.2.2'
 
 dependencies {
   compile "org.apache.commons:commons-lang3:3.7"

--- a/src/main/java/io/thekraken/grok/api/GrokUtils.java
+++ b/src/main/java/io/thekraken/grok/api/GrokUtils.java
@@ -22,7 +22,7 @@ public class GrokUtils {
       "%\\{" +
       "(?<name>" +
         "(?<pattern>[A-z0-9]+)" +
-          "(?::(?<subname>[A-z0-9_:;\\/\\s\\.-]+))?" +
+          "(?::(?<subname>[A-z0-9_:;'\\/\\s\\.-]+))?" +
           ")" +
           "(?:=(?<definition>" +
             "(?:" +

--- a/src/test/java/io/thekraken/grok/api/GrokTest.java
+++ b/src/test/java/io/thekraken/grok/api/GrokTest.java
@@ -616,6 +616,17 @@ public class GrokTest {
         Match match = grok.match("[2019-04-06 16:16:50]");
         DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
         assertEquals(ZonedDateTime.parse("2019-04-06 16:16:50", dtf.withZone(ZoneOffset.UTC)).toInstant(), match.capture().get("timestamp").getValue());
+
+        grok = compiler.compile("\\[%{TIMESTAMP_ISO8601:timestamp:datetime:yyyy-MM-dd'T'HH:mm:ss}\\]");
+        match = grok.match("[2019-04-06T16:16:50]");
+        assertEquals(ZonedDateTime.parse("2019-04-06T16:16:50", DateTimeFormatter.ISO_DATE_TIME.withZone(ZoneOffset.UTC)).toInstant(), match.capture().get("timestamp").getValue());
+    }
+
+    @Test
+    public void testDatetimeWithoutPattern() throws Exception {
+        Grok grok = compiler.compile("\\[%{TIMESTAMP_ISO8601:timestamp:datetime}\\]");
+        Match match = grok.match("[2019-04-06T16:16:50]");
+        assertEquals(ZonedDateTime.parse("2019-04-06T16:16:50", DateTimeFormatter.ISO_DATE_TIME.withZone(ZoneOffset.UTC)).toInstant(), match.capture().get("timestamp").getValue());
     }
 
     @Test


### PR DESCRIPTION
so that you can specify `'T'` in datetime format.

Also added a unit test to verify that GrokParser by default uses [DateTimeFormatter.ISO_DATE_TIME](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_DATE_TIME) to parse the timestamp.