### PR TITLE
grok parser is not handling , well.  it’s because , is not allowed in…

### DIFF
--- a/src/main/java/io/thekraken/grok/api/GrokUtils.java
+++ b/src/main/java/io/thekraken/grok/api/GrokUtils.java
@@ -22,7 +22,7 @@ public class GrokUtils {
       "%\\{" +
       "(?<name>" +
         "(?<pattern>[A-z0-9]+)" +
-          "(?::(?<subname>[A-z0-9_:;'\\/\\s\\.-]+))?" +
+          "(?::(?<subname>[A-z0-9_:,;'\\/\\s\\.-]+))?" +
           ")" +
           "(?:=(?<definition>" +
             "(?:" +

--- a/src/test/java/io/thekraken/grok/api/GrokTest.java
+++ b/src/test/java/io/thekraken/grok/api/GrokTest.java
@@ -635,6 +635,21 @@ public class GrokTest {
     }
 
     @Test
+    public void testRFC2822FormatPattern() throws Exception {
+        Grok grok = compiler.compile("\\[%{DATA:timestamp:datetime:EEE, dd MMM yy HH:mm:ss}\\]");
+        Match match = grok.match("[Sun, 30 Oct 16 17:16:09]");
+
+        ZonedDateTime today = ZonedDateTime.now(ZoneOffset.UTC);
+        ZonedDateTime zdt = ZonedDateTime.ofInstant((Instant) (match.capture().get("timestamp").getValue()), ZoneOffset.UTC);
+
+        assertEquals(10, zdt.getMonthValue());
+        assertEquals(30, zdt.getDayOfMonth());
+        assertEquals(17, zdt.getHour());
+        assertEquals(16, zdt.getMinute());
+        assertEquals(9, zdt.getSecond());
+    }
+
+    @Test
     public void testNoYearPattern() throws Exception {
         Grok grok = compiler.compile("\\[%{DATA:timestamp:datetime:MMM dd HH:mm:ss}\\]");
         Match match = grok.match("[Apr 06 16:16:50]");


### PR DESCRIPTION
grok parser is not handling , well.  it’s because , is not allowed in dashbase GROK_PATTERN. Added comma to fix the issue.
Added junit test.