### PR TITLE
DB-2466 support datetime_delta type

### DIFF
--- a/src/main/java/io/thekraken/grok/api/Converter.java
+++ b/src/main/java/io/thekraken/grok/api/Converter.java
@@ -37,7 +37,8 @@ public class Converter {
     META(v -> v, "sorted"),
 
     // Dashbase specific type
-    ID(v -> v, "key");
+    ID(v -> v, "key"),
+    DATETIME_DELTA(new DateTimeDeltaConverter(), "date_delta");
 
     public final IConverter<?> converter;
     public final List<String> aliases;

--- a/src/main/java/io/thekraken/grok/api/Entity.java
+++ b/src/main/java/io/thekraken/grok/api/Entity.java
@@ -53,6 +53,15 @@ public class Entity {
         additionalEntities.add(entity);
     }
 
+    public Entity withCustomValue(Object customValue) {
+        return new Entity(subject, start, end, ignoreStart, ignoreEnd, converter) {
+            @Override
+            public Object getValue() {
+                return customValue;
+            }
+        };
+    }
+
     @Override
     public String toString() {
         return ignoreStart >= 0 ? getValue().toString() : getValue() + "[" + start + "," + end + "]";

--- a/src/main/java/io/thekraken/grok/api/Grok.java
+++ b/src/main/java/io/thekraken/grok/api/Grok.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.time.ZoneId;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -186,5 +187,9 @@ public class Grok {
       disco = new Discovery(this);
     }
     return disco.discover(input);
+  }
+
+  public Optional<String> getFieldNameOf(Converter.Type type) {
+    return groupTypes.entrySet().stream().filter(e -> e.getValue() == type).map(e -> e.getKey()).findFirst();
   }
 }

--- a/src/main/java/io/thekraken/grok/api/Match.java
+++ b/src/main/java/io/thekraken/grok/api/Match.java
@@ -170,17 +170,6 @@ public class Match {
       });
     });
 
-    this.grok.groupTypes.entrySet().stream()
-        .filter(e -> e.getValue() == Converter.Type.DATETIME_DELTA)
-        .map(e -> e.getKey())
-        .findFirst()
-        .ifPresent(deltaFieldName -> {
-          var delta = capture.get(deltaFieldName);
-
-        });
-
-
-
     capture = Collections.unmodifiableMap(capture);
 
     return capture;

--- a/src/main/java/io/thekraken/grok/api/Match.java
+++ b/src/main/java/io/thekraken/grok/api/Match.java
@@ -18,6 +18,8 @@ package io.thekraken.grok.api;
 
 import com.google.common.collect.Maps;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -116,9 +118,6 @@ public class Match {
 
     capture = Maps.newHashMap();
 
-    // _capture.put("LINE", this.line);
-    // _capture.put("LENGTH", this.line.length() +"");
-
     this.grok.namedGroups.forEach(groupName -> {
       int start = match.start(groupName);
       int end = match.end(groupName);
@@ -160,6 +159,26 @@ public class Match {
         capture.put(groupName, entity);
       }
     });
+
+    // if DATETIME_DELTA field exists, update the value of DATETIME field, and remove the DATETIME_DELTA field.
+    grok.getFieldNameOf(Converter.Type.DATETIME).ifPresent(timestampField -> {
+      grok.getFieldNameOf(Converter.Type.DATETIME_DELTA).ifPresent(deltaField -> {
+        Duration delta = (Duration) capture.remove(deltaField).getValue();
+        Entity timestamp = capture.get(timestampField);
+        var instant = (Instant) timestamp.getValue();
+        capture.put(timestampField, timestamp.withCustomValue(instant.plus(delta)));
+      });
+    });
+
+    this.grok.groupTypes.entrySet().stream()
+        .filter(e -> e.getValue() == Converter.Type.DATETIME_DELTA)
+        .map(e -> e.getKey())
+        .findFirst()
+        .ifPresent(deltaFieldName -> {
+          var delta = capture.get(deltaFieldName);
+
+        });
+
 
 
     capture = Collections.unmodifiableMap(capture);

--- a/src/test/java/io/thekraken/grok/api/GrokTest.java
+++ b/src/test/java/io/thekraken/grok/api/GrokTest.java
@@ -11,6 +11,7 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.time.*;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 
 import static java.lang.String.format;
@@ -748,5 +749,16 @@ public class GrokTest {
         capture = match.capture();
         zdt = ZonedDateTime.ofInstant((Instant) (capture.get("timestamp").getValue()), ZoneOffset.UTC);
         assertEquals("2020-06-02T16:59:59.081Z", DateTimeFormatter.ISO_DATE_TIME.format(zdt));
+    }
+
+    @Test
+    public void testDateTimeDelta() throws Exception {
+        var grok = compiler.compile("Tsec:%{NUMBER:timestamp:datetime:epoch},Tmsec:%{NUMBER:timestamp_delta:datetime_delta}");
+
+        var match = grok.match("Tsec:1596726855,Tmsec:541834");
+        var capture = match.capture();
+        var timestamp = capture.get("timestamp");
+        assertEquals(1596726855541L, ((Instant) timestamp.getValue()).toEpochMilli());
+        assertFalse(capture.containsKey("timestamp_delta"));
     }
 }


### PR DESCRIPTION
adding `datetime_delta` data type, which can be used to adjust the value of `datetime` field.

e.g., with this pattern `Tsec:%{NUMBER:timestamp:datetime:epoch},Tmsec:%{NUMBER:timestamp_delta:datetime_delta}`, the value specified after `Tmsec` is added as a microsecond to the value of the epoch second in `Tsec`.

you can specify the time unit of delta. e.g., `%{NUMBER:timestamp_delta:datetime_delta:millis}` will parse the value as milliseconds. the possible units are the ones defined in [ChronoUnit](https://docs.oracle.com/javase/8/docs/api/java/time/temporal/ChronoUnit.html) enum.